### PR TITLE
Automatically restart the container instead of exiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,3 +123,6 @@ RUN chmod +x start.sh devmapper/*.sh
 ENTRYPOINT [ "/sbin/tini", "--" ]
 
 CMD [ "/app/start.sh" ]
+
+ENV FICD_IMAGE_TAG docker.io/library/busybox:latest
+ENV FICD_KEEP_ALIVE false

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ lsmod | grep kvm
 
 ## Usage
 
-Set the env var `RUN_IMAGE` to the desired OCI-compliant container image and optionally provide a `RUN_COMMAND`.
-Runtime options can be provided via `EXTRA_RUN_OPTS` and `EXTRA_RUN_FLAGS`.
+Set the env var `FICD_IMAGE_TAG` to the desired OCI-compliant container image and optionally provide a `FICD_CMD`.
+Additional container runtime options can be provided via `FICD_EXTRA_OPTS`.
 For a full list of options execute `firecracker-ctr run --help` in the service shell.
 
 ## Contributing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,4 +13,5 @@ services:
     volumes:
       - data:/var/lib/firecracker-containerd
     environment:
-      RUN_IMAGE: docker.io/library/hello-world:latest
+      FICD_IMAGE_TAG: docker.io/library/hello-world:latest
+      FICD_KEEP_ALIVE: false

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: balena


### PR DESCRIPTION
This should save devmapper cleanup and creation steps for containers that are expected to be ephemeral and restart often.

Change-type: patch